### PR TITLE
Poll and Rejoin Active Match

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,6 +112,20 @@ const App: FC = () => {
         if (difficultyNameFound) setDifficultyName(difficultyNameFound);
     }, 1000);
 
+    useInterval(() => {
+
+        const currentMatch = client.getMatch(matchUUID);
+
+        if (!currentMatch) return;
+        const isMatchConnected = client.getMatchWebsocketUsers(currentMatch).find((sockUser) => sockUser.guid == client.Self.guid);
+
+        if (!isMatchConnected) {
+            currentMatch.associated_users.push(client.Self.guid);
+            client.updateMatch(currentMatch);
+        }
+
+    }, 10000);
+
     return (
         <>
             <div className="overlay">


### PR DESCRIPTION
This should fix the missing score information issue. Polls the match every 10 seconds to check what WebSocket connections are considered as connected users for the match. If the current connection isn't in the list, it then adds itself to the list.