### PR TITLE
Add swapping scores between halves

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,7 +162,7 @@ const App: FC = () => {
                 </h1>
 
                 <h1
-                    className="switchSidesConfirmationText"
+                    className="waitText"
                     style={{
                         opacity: confirmFlip ? 1 : 0,
                     }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,24 @@ const App: FC = () => {
     const [songName, setSongName] = useState('');
     const [difficultyName, setDifficultyName] = useState('');
 
+    const [confirmFlip, setConfirmFlip] = useState(false);
+
+    const switchScores = () => {
+        if (inMatch) { // No need to do any of this if there isn't a match in progress (Positive Side Effect: Prevents text overlap)
+            const oldLeftPlayerUUID = leftPlayerUUID;
+
+            if (confirmFlip == false) {
+                console.log(confirmFlip);
+                setConfirmFlip(true);
+                return;
+            }
+            
+            setLeftPlayerUUID(rightPlayerUUID || '');
+            setRightPlayerUUID(oldLeftPlayerUUID || '');
+            setConfirmFlip(false);
+        }
+    }
+
     const onMatchCreated: EventReceiver<TAEvents.PacketEvent<Models.Match>> = ({
         data
     }) => {
@@ -128,7 +146,7 @@ const App: FC = () => {
 
     return (
         <>
-            <div className="overlay">
+            <div className="overlay" onClick={switchScores}>
                 <h1
                     className="waitText"
                     style={{
@@ -136,6 +154,15 @@ const App: FC = () => {
                     }}
                 >
                     Waiting For The Next Match...
+                </h1>
+
+                <h1
+                    className="switchSidesConfirmationText"
+                    style={{
+                        opacity: confirmFlip ? 1 : 0,
+                    }}
+                >
+                    Click again to confirm switching scores...
                 </h1>
 
                 <h1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,14 +47,19 @@ const App: FC = () => {
             const oldLeftPlayerUUID = leftPlayerUUID;
 
             if (confirmFlip == false) {
-                console.log(confirmFlip);
                 setConfirmFlip(true);
+
+                setTimeout(function() {
+                    setConfirmFlip(false);
+                }, 3000);
+
                 return;
             }
             
             setLeftPlayerUUID(rightPlayerUUID || '');
             setRightPlayerUUID(oldLeftPlayerUUID || '');
             setConfirmFlip(false);
+
         }
     }
 


### PR DESCRIPTION
Scores can now swap sides by clicking the info text bar on top of the overlay twice (Once to display a confirmation message, again to confirm.)

There is technically a minor bug(?) where if you flip the scores and re-trigger the confirmation before the 3 second reset from the first trigger it will clear away the confirmation message still. This doesn't really affect anything unless you are spam clicking it however.